### PR TITLE
fix: correct variable name in geofencingService isInsidePolygon

### DIFF
--- a/src/services/geofencingService.ts
+++ b/src/services/geofencingService.ts
@@ -385,14 +385,14 @@ class GeofencingService {
         lastUpdated: new Date(),
       },
     };
-    
+
     this.geofences.set(id, newGeofence);
-    
+
     // Check if user is already inside
     if (this.lastLocation && newGeofence.active) {
       this.checkGeofence(newGeofence, this.lastLocation);
     }
-    
+
     this.notifyStatusChange();
     return newGeofence;
   }
@@ -526,11 +526,11 @@ class GeofencingService {
     if (isInside && !wasInside) {
       // Entered geofence
       this.activeGeofences.add(geofence.id);
-      
+
       if (geofence.triggerOnEnter) {
         this.triggerEvent(geofence, 'enter', location);
       }
-      
+
       if (geofence.triggerOnDwell && geofence.dwellTime) {
         this.startDwellTimer(geofence, location);
       }
@@ -538,7 +538,7 @@ class GeofencingService {
       // Exited geofence
       this.activeGeofences.delete(geofence.id);
       this.clearDwellTimer(geofence.id);
-      
+
       if (geofence.triggerOnExit) {
         this.triggerEvent(geofence, 'exit', location);
       }
@@ -589,8 +589,8 @@ class GeofencingService {
       const yj = polygon[j].latitude;
 
       const intersect =
-        yi > point.latitude !== yj > point.latitude &&
-        point.longitude < ((xj - xi) * (point.latitude - yi)) / (yj - yi) + xi;
+        yi > y !== yj > y &&
+        x < ((xj - xi) * (y - yi)) / (yj - yi) + xi;
 
       if (intersect) inside = !inside;
     }


### PR DESCRIPTION
Fixes #295

## Description
The `isInsidePolygon` method in GeofencingService uses an undefined variable `point` instead of the already destructured `x` and `y` variables from the location parameter.

## Changes Made
- Corrected the variable name from `point.latitude` to `y` and `point.longitude` to `x` inside the intersection check logic.

## Testing
- Verified with TypeScript compiler that the error is resolved.
- Verified the logic matches the intended ray-casting algorithm for polygon intersection.