### PR TITLE
Fix: remove hardcoded OpenWeather API key

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -11,10 +11,16 @@ import urllib.parse
 import json
 import os
 import random
+from dotenv import load_dotenv
+
+load_dotenv()
 
 # OpenWeatherMap API key
-OPENWEATHER_API_KEY = os.getenv("OPENWEATHER_API_KEY", "1801423b3942e324ab80f5b47afe0859")
 
+OPENWEATHER_API_KEY = os.getenv("OPENWEATHER_API_KEY")
+
+if not OPENWEATHER_API_KEY:
+    raise RuntimeError("OPENWEATHER_API_KEY is not set")
 # USGS Earthquake API
 USGS_EARTHQUAKE_URL = "https://earthquake.usgs.gov/fdsnws/event/1/query"
 


### PR DESCRIPTION
This PR fixes the security issue related to a hardcoded OpenWeather API key in the backend.
The API key has been removed from the source code and is now handled using environment variables.
Fixes #266
Note:
The Netlify deploy preview fails because the OPENWEATHER_API_KEY environment variable
is not set in the preview environment. This is expected, as the key is now managed
via environment variables in production for security reasons.

<img width="898" height="441" alt="just" src="https://github.com/user-attachments/assets/cd8afba7-35b8-4de7-b325-f73a58b0462f" />
